### PR TITLE
Allow rules

### DIFF
--- a/src/services/CraftNamedRoutesService.php
+++ b/src/services/CraftNamedRoutesService.php
@@ -49,7 +49,7 @@ class CraftNamedRoutesService extends Component
             $manager = Craft::$app->getUrlManager();
             $rules = Craft::$app->getUrlManager()->rules;
             foreach ($rules as $rule) {
-                if(isset($rule->name) && $rule->name == $route_name){
+                if(isset($rule->$keyword) && $rule->$keyword == $route_name){
                     $selected_route = $rule->createUrl($manager, $rule->route, $provided_tokens);
                 }
             }

--- a/src/services/CraftNamedRoutesService.php
+++ b/src/services/CraftNamedRoutesService.php
@@ -45,6 +45,16 @@ class CraftNamedRoutesService extends Component
             }
         }
 
+        if (is_null($selected_route = null)) {
+            $manager = Craft::$app->getUrlManager();
+            $rules = Craft::$app->getUrlManager()->rules;
+            foreach ($rules as $rule) {
+                if(isset($rule->name) && $rule->name == $route_name){
+                    $selected_route = $rule->createUrl($manager, $rule->route, $provided_tokens);
+                }
+            }
+        }
+
         // exception if no route with provided name was found
         if(is_null($selected_route)){
             throw new RuntimeError(sprintf('Route "%s" was not found.', $route_name));


### PR DESCRIPTION
The current implementation does not allow named rules from installed modules. i.e.

```
        Event::on(
            UrlManager::class,
            UrlManager::EVENT_REGISTER_SITE_URL_RULES,
            function(RegisterUrlRulesEvent $event) {
                $event->rules['site/<postSlug:{slug}>/comments/'] = ['route' => 'site/posts/list-comments', 'name' => 'listPostComments'];
            }
```